### PR TITLE
Fix find_music_file to use CUE FILE directive for audio lookup

### DIFF
--- a/app/split_image.py
+++ b/app/split_image.py
@@ -345,7 +345,14 @@ def run_service(cue_file, music_file, music_outdir_fpath, base_dir, ext, sim_mod
 
 
 def parse_cue_file_reference(cue_file):
-    """Return the filename from the first FILE directive in a CUE sheet."""
+    """Return (filename, file_count) from FILE directives in a CUE sheet.
+
+    Returns the first referenced filename and the total count of FILE lines.
+    A single-file CUE sheet has exactly 1 FILE directive pointing to an audio
+    image; multi-file CUE sheets have one FILE per track and cannot be split.
+    """
+    first_ref = None
+    count = 0
     try:
         encoding = detect_encoding(cue_file) or 'utf-8'
         with open(cue_file, 'r', encoding=encoding, errors='ignore') as f:
@@ -353,14 +360,21 @@ def parse_cue_file_reference(cue_file):
                 if line.strip().upper().startswith('FILE '):
                     parts = line.strip().split('"')
                     if len(parts) >= 2:
-                        return parts[1]
+                        if first_ref is None:
+                            first_ref = parts[1]
+                        count += 1
     except Exception:
         pass
-    return None
+    return first_ref, count
 
 
 def find_music_file(cue_file, music_indir_fpath):
-    cue_ref = parse_cue_file_reference(cue_file)
+    cue_ref, file_count = parse_cue_file_reference(cue_file)
+
+    # Multi-file CUE sheets (one FILE per track) are not splittable images
+    if file_count > 1:
+        return None, None
+
     if cue_ref:
         ref_path = os.path.join(music_indir_fpath, cue_ref)
         ref_ext = os.path.splitext(cue_ref)[1].lstrip('.')

--- a/app/split_image.py
+++ b/app/split_image.py
@@ -344,20 +344,55 @@ def run_service(cue_file, music_file, music_outdir_fpath, base_dir, ext, sim_mod
         cleanup(music_file, base_dir)
 
 
+def parse_cue_file_reference(cue_file):
+    """Return the filename from the first FILE directive in a CUE sheet."""
+    try:
+        encoding = detect_encoding(cue_file) or 'utf-8'
+        with open(cue_file, 'r', encoding=encoding, errors='ignore') as f:
+            for line in f:
+                if line.strip().upper().startswith('FILE '):
+                    parts = line.strip().split('"')
+                    if len(parts) >= 2:
+                        return parts[1]
+    except Exception:
+        pass
+    return None
+
+
 def find_music_file(cue_file, music_indir_fpath):
+    cue_ref = parse_cue_file_reference(cue_file)
+    if cue_ref:
+        ref_path = os.path.join(music_indir_fpath, cue_ref)
+        ref_ext = os.path.splitext(cue_ref)[1].lstrip('.')
+
+        # Step 1: exact match from FILE directive
+        if os.path.exists(ref_path) and ref_ext in SPLIT_FILE_TYPES:
+            return ref_path, ref_ext
+
+        # Step 2: same stem, try each supported extension (e.g. .wav -> .wv/.flac)
+        ref_stem = os.path.splitext(ref_path)[0]
+        for file_ext in SPLIT_FILE_TYPES:
+            candidate = f"{ref_stem}.{file_ext}"
+            if os.path.exists(candidate):
+                return candidate, file_ext
+
+        # Step 3: FILE directive exists but names differ — if exactly one supported
+        # audio file is present in the folder, it must be the image
+        for file_ext in SPLIT_FILE_TYPES:
+            matches = [f for f in os.listdir(music_indir_fpath) if f.endswith(f'.{file_ext}')]
+            if len(matches) == 1:
+                return os.path.join(music_indir_fpath, matches[0]), file_ext
+
+    # Fallback: derive audio filename from CUE filename stem
     for file_ext in SPLIT_FILE_TYPES:
         root, ext = os.path.splitext(cue_file)
-
         if root.endswith(file_ext):
             music_file = root
         else:
             music_file = f"{root}.{file_ext}"
-
         music_file = os.path.join(music_indir_fpath, music_file)
         logging.debug(f'-- {music_file}')
         if os.path.exists(music_file):
-            music_file.replace("'", "")
-            music_file.replace("'", "")
             return music_file, file_ext
     return None, None
 


### PR DESCRIPTION
## Summary
- `find_music_file` previously only matched audio by CUE filename stem, missing cases where the CUE and audio file have different names
- Added `parse_cue_file_reference` to read the `FILE "..."` directive from the CUE sheet
- Three-step resolution: (1) exact path match, (2) same stem with supported extension (handles `.wav` → `.wv`/`.flac`), (3) single audio file in folder (handles completely different names)
- Fixes 4 folders in `/Volumes/downloads` that had valid image+cue pairs but were silently skipped

## Test plan
- [ ] Lowrider — `FILE "Lowrider - Ode to Io.wv"` → exact `.wv` match (step 1)
- [ ] Lowrider (wav) — `FILE "Lowrider - Ode to Io.wav"` → same stem, `.wv` found (step 2)
- [ ] Holy Wars Promo — `FILE "Megadeth - Holy Wars... The Punishment Due (Promo).flac"` → 1 `.flac` in folder (step 3)
- [ ] Small Faces CD1 ISRC — `FILE "Range.wav"` → 1 `.flac` in folder (step 3)
- [ ] Existing matched pairs (63 folders) continue to work via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUE sheet handling so the app now prefers explicit file references in CUEs, treats multi-file CUEs as non-splittable, and uses multiple matching strategies to more reliably locate the associated audio file.
  * Removed redundant string-cleaning operations to streamline file matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->